### PR TITLE
Extend Post Page Functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,11 @@
       "dependencies": {
         "@heroicons/react": "^2.1.5",
         "@mdxeditor/editor": "^3.11.5",
-        "@radix-ui/react-dropdown-menu": "^2.1.1",
+        "@radix-ui/react-alert-dialog": "^1.1.2",
+        "@radix-ui/react-dropdown-menu": "^2.1.2",
         "@radix-ui/react-icons": "^1.3.0",
         "@radix-ui/react-popover": "^1.1.1",
+        "@radix-ui/react-slot": "^1.1.0",
         "@radix-ui/react-toast": "^1.2.1",
         "@radix-ui/react-toggle": "^1.1.0",
         "@radix-ui/react-toggle-group": "^1.1.0",
@@ -1983,6 +1985,49 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.0.tgz",
       "integrity": "sha512-4Z8dn6Upk0qk4P74xBhZ6Hd/w0mPEzOOLxy4xiPXOXqjF7jZS0VAKk7/x/H6FyY2zCkYJqePf1G5KmkmNJ4RBA=="
     },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.2.tgz",
+      "integrity": "sha512-eGSlLzPhKO+TErxkiGcCZGuvbVMnLA1MTnyBksGOeGRGkxHiiJUujsjmNTdWTm4iHVSRaUao9/4Ur671auMghQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-dialog": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-slot": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-context": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.1.tgz",
+      "integrity": "sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.0.tgz",
@@ -2059,24 +2104,25 @@
       }
     },
     "node_modules/@radix-ui/react-dialog": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.1.tgz",
-      "integrity": "sha512-zysS+iU4YP3STKNS6USvFVqI4qqx8EpiwmT5TuCApVEBca+eRCbONi4EgzfNSuVnOXvC5UPHHMjs8RXO6DH9Bg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.2.tgz",
+      "integrity": "sha512-Yj4dZtqa2o+kG61fzB0H2qUvmwBA2oyQroGLyNtBj1beo1khoQ3q1a2AO8rrQYjd8256CO9+N8L9tvsS+bnIyA==",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.0",
         "@radix-ui/react-compose-refs": "1.1.0",
-        "@radix-ui/react-context": "1.1.0",
-        "@radix-ui/react-dismissable-layer": "1.1.0",
-        "@radix-ui/react-focus-guards": "1.1.0",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.1",
+        "@radix-ui/react-focus-guards": "1.1.1",
         "@radix-ui/react-focus-scope": "1.1.0",
         "@radix-ui/react-id": "1.1.0",
-        "@radix-ui/react-portal": "1.1.1",
-        "@radix-ui/react-presence": "1.1.0",
+        "@radix-ui/react-portal": "1.1.2",
+        "@radix-ui/react-presence": "1.1.1",
         "@radix-ui/react-primitive": "2.0.0",
         "@radix-ui/react-slot": "1.1.0",
         "@radix-ui/react-use-controllable-state": "1.1.0",
         "aria-hidden": "^1.1.1",
-        "react-remove-scroll": "2.5.7"
+        "react-remove-scroll": "2.6.0"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2089,6 +2135,136 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-context": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.1.tgz",
+      "integrity": "sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.1.tgz",
+      "integrity": "sha512-QSxg29lfr/xcev6kSz7MAlmDnzbP1eI/Dwn3Tp1ip0KT5CUELsxkekFEMVBEoykI3oV39hKT4TKZzBNMbcTZYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-escape-keydown": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.1.tgz",
+      "integrity": "sha512-pSIwfrT1a6sIoDASCSpFwOasEwKTZWDw/iBdtnqKO7v6FeOzYJ7U53cPzYFVR3geGGXgVHaH+CdngrrAzqUGxg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-portal": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.2.tgz",
+      "integrity": "sha512-WeDYLGPxJb/5EGBoedyJbT0MpoULmwnIPMJMSldkuiMsBAv7N1cRdsTWZWht9vpPOiN3qyiGAtbK2is47/uMFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.1.tgz",
+      "integrity": "sha512-IeFXVi4YS1K0wVZzXNrbaaUvIJ3qdY+/Ih4eHFhWA9SwGR9UDX7Ck8abvL57C4cv3wwMvUE0OG69Qc3NCcTe/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/react-remove-scroll": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.6.0.tgz",
+      "integrity": "sha512-I2U4JVEsQenxDAKaVa3VZ/JeJZe0/2DxPWL8Tj8yLKctQJQiZM52pn/GWFpSp8dftjM3pSAHVJZscAnC/y+ySQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.6",
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -2134,15 +2310,16 @@
       }
     },
     "node_modules/@radix-ui/react-dropdown-menu": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.1.tgz",
-      "integrity": "sha512-y8E+x9fBq9qvteD2Zwa4397pUVhYsh9iq44b5RD5qu1GMJWBCBuVg1hMyItbc6+zH00TxGRqd9Iot4wzf3OoBQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.2.tgz",
+      "integrity": "sha512-GVZMR+eqK8/Kes0a36Qrv+i20bAPXSn8rCBTHx30w+3ECnR5o3xixAlqcVaYvLeyKUsm0aqyhWfmUcqufM8nYA==",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.0",
         "@radix-ui/react-compose-refs": "1.1.0",
-        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-context": "1.1.1",
         "@radix-ui/react-id": "1.1.0",
-        "@radix-ui/react-menu": "2.1.1",
+        "@radix-ui/react-menu": "2.1.2",
         "@radix-ui/react-primitive": "2.0.0",
         "@radix-ui/react-use-controllable-state": "1.1.0"
       },
@@ -2157,6 +2334,21 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-context": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.1.tgz",
+      "integrity": "sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -2225,28 +2417,29 @@
       }
     },
     "node_modules/@radix-ui/react-menu": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.1.tgz",
-      "integrity": "sha512-oa3mXRRVjHi6DZu/ghuzdylyjaMXLymx83irM7hTxutQbD+7IhPKdMdRHD26Rm+kHRrWcrUkkRPv5pd47a2xFQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.2.tgz",
+      "integrity": "sha512-lZ0R4qR2Al6fZ4yCCZzu/ReTFrylHFxIqy7OezIpWF4bL0o9biKo0pFIvkaew3TyZ9Fy5gYVrR5zCGZBVbO1zg==",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.0",
         "@radix-ui/react-collection": "1.1.0",
         "@radix-ui/react-compose-refs": "1.1.0",
-        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-context": "1.1.1",
         "@radix-ui/react-direction": "1.1.0",
-        "@radix-ui/react-dismissable-layer": "1.1.0",
-        "@radix-ui/react-focus-guards": "1.1.0",
+        "@radix-ui/react-dismissable-layer": "1.1.1",
+        "@radix-ui/react-focus-guards": "1.1.1",
         "@radix-ui/react-focus-scope": "1.1.0",
         "@radix-ui/react-id": "1.1.0",
         "@radix-ui/react-popper": "1.2.0",
-        "@radix-ui/react-portal": "1.1.1",
-        "@radix-ui/react-presence": "1.1.0",
+        "@radix-ui/react-portal": "1.1.2",
+        "@radix-ui/react-presence": "1.1.1",
         "@radix-ui/react-primitive": "2.0.0",
         "@radix-ui/react-roving-focus": "1.1.0",
         "@radix-ui/react-slot": "1.1.0",
         "@radix-ui/react-use-callback-ref": "1.1.0",
         "aria-hidden": "^1.1.1",
-        "react-remove-scroll": "2.5.7"
+        "react-remove-scroll": "2.6.0"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2259,6 +2452,136 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-context": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.1.tgz",
+      "integrity": "sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.1.tgz",
+      "integrity": "sha512-QSxg29lfr/xcev6kSz7MAlmDnzbP1eI/Dwn3Tp1ip0KT5CUELsxkekFEMVBEoykI3oV39hKT4TKZzBNMbcTZYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-escape-keydown": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.1.tgz",
+      "integrity": "sha512-pSIwfrT1a6sIoDASCSpFwOasEwKTZWDw/iBdtnqKO7v6FeOzYJ7U53cPzYFVR3geGGXgVHaH+CdngrrAzqUGxg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-portal": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.2.tgz",
+      "integrity": "sha512-WeDYLGPxJb/5EGBoedyJbT0MpoULmwnIPMJMSldkuiMsBAv7N1cRdsTWZWht9vpPOiN3qyiGAtbK2is47/uMFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.1.tgz",
+      "integrity": "sha512-IeFXVi4YS1K0wVZzXNrbaaUvIJ3qdY+/Ih4eHFhWA9SwGR9UDX7Ck8abvL57C4cv3wwMvUE0OG69Qc3NCcTe/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/react-remove-scroll": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.6.0.tgz",
+      "integrity": "sha512-I2U4JVEsQenxDAKaVa3VZ/JeJZe0/2DxPWL8Tj8yLKctQJQiZM52pn/GWFpSp8dftjM3pSAHVJZscAnC/y+ySQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.6",
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -2496,6 +2819,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.0.tgz",
       "integrity": "sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -16,9 +16,11 @@
   "dependencies": {
     "@heroicons/react": "^2.1.5",
     "@mdxeditor/editor": "^3.11.5",
-    "@radix-ui/react-dropdown-menu": "^2.1.1",
+    "@radix-ui/react-alert-dialog": "^1.1.2",
+    "@radix-ui/react-dropdown-menu": "^2.1.2",
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-popover": "^1.1.1",
+    "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-toast": "^1.2.1",
     "@radix-ui/react-toggle": "^1.1.0",
     "@radix-ui/react-toggle-group": "^1.1.0",

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -26,7 +26,7 @@ export default function Login() {
               <i className="fa fa-user"></i>
             </i>
             
-            <input className="border-[1px] border-gray-300 rounded-sm pr-3.5 pl-10 h-[51px] w-[295px] placeholder-med-gray text-med-gray focus:outline-none focus:ring-2 focus:ring-blue-500" type="email" placeholder="Username" />
+            <input className="border-[1px] border-gray-300 rounded-sm pr-3.5 pl-10 h-[51px] w-[295px] placeholder-theme-med-gray text-theme-med-gray focus:outline-none focus:ring-2 focus:ring-blue-500" type="email" placeholder="Username" />
           </div>
 
           <div className="relative mt-4">
@@ -34,7 +34,7 @@ export default function Login() {
               <Image src={lock} width={17} alt="lock-icon" />
               <i className="fa fa-lock"></i>
             </i>
-            <input className="border-[1px] border-gray-300 pr-3.5 rounded-sm h-[51px] pl-10 w-[295px] placeholder-med-gray text-med-gray focus:outline-none focus:ring-2 focus:ring-blue-500" type="password" placeholder="Password" />
+            <input className="border-[1px] border-gray-300 pr-3.5 rounded-sm h-[51px] pl-10 w-[295px] placeholder-theme-med-gray text-theme-med-gray focus:outline-none focus:ring-2 focus:ring-blue-500" type="password" placeholder="Password" />
           </div>
           {credentialsError && (
             <p className="text-red-500 text-sm mt-2">Invalid username or password. Please try again.</p>

--- a/src/app/(community)/page.tsx
+++ b/src/app/(community)/page.tsx
@@ -1,10 +1,8 @@
 import { getPopulatedPosts } from "@/server/db/actions/PostActions";
 import PostComponent from "@/components/PostComponent";
+import { USER_ID } from "@/utils/consts";
 
 export const dynamic = 'force-dynamic';
-
-// Dummy ID to be replaced with authenticated user when auth is implemented
-const USER_ID = '66e26a641737b310a1b2774c';
 
 export default async function Home() {
   const posts = await getPopulatedPosts(USER_ID);

--- a/src/app/(community)/page.tsx
+++ b/src/app/(community)/page.tsx
@@ -3,8 +3,11 @@ import PostComponent from "@/components/PostComponent";
 
 export const dynamic = 'force-dynamic';
 
+// Dummy ID to be replaced with authenticated user when auth is implemented
+const USER_ID = '66e26a641737b310a1b2774c';
+
 export default async function Home() {
-  const posts = await getPopulatedPosts();
+  const posts = await getPopulatedPosts(USER_ID);
 
   return (
     <main className="flex min-h-screen flex-col items-center p-16">

--- a/src/app/(community)/page.tsx
+++ b/src/app/(community)/page.tsx
@@ -70,21 +70,10 @@ export default function Home() {
     }
   };
 
-  // update filter when selectedDisabilities changes
-  useEffect(() => {
-    if (selectedDisabilities.length > 0) {
-      setFilter({
-        tags: { $in: selectedDisabilities.map((d) => d._id) },
-      });
-    } else {
-      setFilter({});
-    }
-  }, [selectedDisabilities])
-
   // fetch posts when filter changes
   useEffect(() => {
     fetchPosts(true);
-  }, [filter])
+  }, [selectedDisabilities])
 
   // Fetch posts when page changes
   const fetchPosts = async (clear: boolean = false) => {
@@ -99,7 +88,9 @@ export default function Home() {
     try {
       const newPage = clear ? 0 : page;
 
-      const newPosts = await getPopulatedPosts(USER_ID, newPage * PAGINATION_LIMIT, PAGINATION_LIMIT, filter);
+      const tags = selectedDisabilities.map((disability) => disability._id);
+
+      const newPosts = await getPopulatedPosts(USER_ID, newPage * PAGINATION_LIMIT, PAGINATION_LIMIT, tags);
       if (newPosts.length > 0) {
         setPosts(clear ? newPosts : [...posts, ...newPosts]);
       } else {

--- a/src/app/(community)/posts/[id]/page.tsx
+++ b/src/app/(community)/posts/[id]/page.tsx
@@ -15,16 +15,8 @@ type PostPageProps = {
 
 export default async function PostPage(props: PostPageProps) {
   const id = props.params.id;
-  let post;
   let authUser;
-
-  try {
-    post = await getPopulatedPost(id);
-  } catch (e) {}
-
-  if (!post) {
-    notFound();
-  }
+  let post;
 
   try {
     authUser = await getUser(USER_ID);
@@ -33,7 +25,15 @@ export default async function PostPage(props: PostPageProps) {
     return 'User matching USER_ID constant not found';
   }
 
-  const comments = await getPostComments(id);
+  try {
+    post = await getPopulatedPost(id, authUser._id);
+  } catch (e) {}
 
-  return <PostCommentsContainer post={post} initialComments={comments} authUser={authUser} />;
+  if (!post) {
+    notFound();
+  }
+
+  const comments = await getPostComments(id, authUser._id);
+
+  return <PostCommentsContainer post={post} comments={comments} authUser={authUser} />;
 }

--- a/src/app/(community)/posts/[id]/page.tsx
+++ b/src/app/(community)/posts/[id]/page.tsx
@@ -3,7 +3,11 @@
 import PostCommentsContainer from "@/components/PostPage/PostCommentsContainer";
 import { getPostComments } from "@/server/db/actions/CommentActions";
 import { getPopulatedPost } from "@/server/db/actions/PostActions";
+import { getUser } from "@/server/db/actions/UserActions";
 import { notFound } from 'next/navigation';
+
+// Dummy ID to be replaced with authenticated user when auth is implemented
+const USER_ID = '66e26a641737b310a1b2774c';
 
 type PostPageProps = {
   params: { id: string }
@@ -12,6 +16,7 @@ type PostPageProps = {
 export default async function PostPage(props: PostPageProps) {
   const id = props.params.id;
   let post;
+  let authUser;
 
   try {
     post = await getPopulatedPost(id);
@@ -21,7 +26,14 @@ export default async function PostPage(props: PostPageProps) {
     notFound();
   }
 
+  try {
+    authUser = await getUser(USER_ID);
+  } catch (e) {
+    // TODO: Handle this properly when auth is implemented - for now, USER_ID must point to a valid user
+    return 'User matching USER_ID constant not found';
+  }
+
   const comments = await getPostComments(id);
 
-  return <PostCommentsContainer post={post} initialComments={comments} />;
+  return <PostCommentsContainer post={post} initialComments={comments} authUser={authUser} />;
 }

--- a/src/app/(community)/posts/[id]/page.tsx
+++ b/src/app/(community)/posts/[id]/page.tsx
@@ -1,5 +1,3 @@
-'use server'
-
 import PostCommentsContainer from "@/components/PostPage/PostCommentsContainer";
 import { getPostComments } from "@/server/db/actions/CommentActions";
 import { getPopulatedPost } from "@/server/db/actions/PostActions";
@@ -10,6 +8,8 @@ import { notFound } from 'next/navigation';
 type PostPageProps = {
   params: { id: string }
 };
+
+export const dynamic = 'force-dynamic';
 
 export default async function PostPage(props: PostPageProps) {
   const id = props.params.id;

--- a/src/app/(community)/posts/[id]/page.tsx
+++ b/src/app/(community)/posts/[id]/page.tsx
@@ -4,10 +4,8 @@ import PostCommentsContainer from "@/components/PostPage/PostCommentsContainer";
 import { getPostComments } from "@/server/db/actions/CommentActions";
 import { getPopulatedPost } from "@/server/db/actions/PostActions";
 import { getUser } from "@/server/db/actions/UserActions";
+import { USER_ID } from "@/utils/consts";
 import { notFound } from 'next/navigation';
-
-// Dummy ID to be replaced with authenticated user when auth is implemented
-const USER_ID = '66e26a641737b310a1b2774c';
 
 type PostPageProps = {
   params: { id: string }

--- a/src/app/api/seeder/route.ts
+++ b/src/app/api/seeder/route.ts
@@ -120,6 +120,7 @@ export async function POST(request: Request) {
     for (let i = 0; i < posts.length; i++) {
       const post = posts[i];
       const numberOfComments = Math.floor(Math.random() * (MAX_COMMENTS_PER_POST + 1));
+      const postComments = [];
 
       for (let j = 0; j < numberOfComments; j++) {
         const commentInfo: CommentInput = {
@@ -129,14 +130,15 @@ export async function POST(request: Request) {
           content: faker.lorem.sentences(),
         }
         
-        if (comments.length > 0) {
-          const randomIndex = Math.floor(Math.random() * comments.length);
-          if (commentInfo.date && comments[randomIndex].date < commentInfo.date) {
-            commentInfo.replyTo = comments[randomIndex]._id;
+        if (postComments.length > 0) {
+          const randomIndex = Math.floor(Math.random() * postComments.length);
+          if (commentInfo.date && postComments[randomIndex].date < commentInfo.date) {
+            commentInfo.replyTo = postComments[randomIndex]._id;
           }
         }
-
-        comments.push(await createComment(commentInfo));
+        const newComment = await createComment(commentInfo);
+        postComments.push(newComment);
+        comments.push(newComment);
       }
     }
     console.log("Successfully created comments");

--- a/src/components/CommentComponent.tsx
+++ b/src/components/CommentComponent.tsx
@@ -86,7 +86,7 @@ export default function CommentComponent(props: CommentComponentProps) {
   return (
     <div className="flex gap-2.5">
       <div>
-        <span className="w-6 h-6 bg-[#D9D9D9] rounded-full inline-block"/>
+        <span className="w-6 h-6 bg-theme-gray rounded-full inline-block"/>
       </div>
       <div className={`flex-grow flex flex-col gap-2 text-theme-gray ${className}`}>
         <div className="flex items-center justify-between">
@@ -95,42 +95,34 @@ export default function CommentComponent(props: CommentComponentProps) {
           </div>
           <p className="text-sm" suppressHydrationWarning>{getDateDifferenceString(new Date(), date)}</p>
         </div>
-        <div className={`flex-grow flex flex-col gap-2 text-focus-gray ${className}`}>
-          <div className="flex items-center justify-between">
-            <div className="font-bold text-black">
-              {author ? `${author.lastName} Family` : 'Deleted User'}
+        <MarkdownRenderer
+          className="leading-5"
+          markdown={content}
+          parse={markdown => mdParser.render(markdown)}
+        />
+        <div className="flex items-center pt-2 gap-6 text-sm">
+          {bottomRow.map((item, index) => (
+            <div key={index} className="flex items-center gap-1.5 px-1">
+              <button disabled={!item.onClick} onClick={item.onClick}>
+                <div className="w-5 h-5 [&>*]:w-full [&>*]:h-full">
+                  {item.icon}
+                </div>
+              </button>
+              {item.label}
             </div>
-            <p className="text-sm" suppressHydrationWarning>{getDateDifferenceString(new Date(), date)}</p>
+          ))}
+          <div className="flex items-center gap-1.5 px-1">
+            <DropdownMenu modal={false}>
+              <DropdownMenuTrigger>
+                <Ellipsis className="w-5 h-5" />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent side="bottom" align="start">
+                {onDeleteClick ? <DropdownMenuItem onClick={() => setShowDeleteDialog(true)}>Delete</DropdownMenuItem> : undefined}
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
-          <MarkdownRenderer
-            className="leading-5"
-            markdown={content}
-            parse={markdown => mdParser.render(markdown)}
-          />
-          <div className="flex items-center pt-2 gap-6 text-sm">
-            {bottomRow.map((item, index) => (
-              <div key={index} className="flex items-center gap-1.5 px-1">
-                <button disabled={!item.onClick} onClick={item.onClick}>
-                  <div className="w-5 h-5 [&>*]:w-full [&>*]:h-full">
-                    {item.icon}
-                  </div>
-                </button>
-                {item.label}
-              </div>
-            ))}
-            <div className="flex items-center gap-1.5 px-1">
-              <DropdownMenu modal={false}>
-                <DropdownMenuTrigger>
-                  <Ellipsis className="w-5 h-5" />
-                </DropdownMenuTrigger>
-                <DropdownMenuContent side="bottom" align="start">
-                  {onDeleteClick ? <DropdownMenuItem onClick={() => setShowDeleteDialog(true)}>Delete</DropdownMenuItem> : undefined}
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </div>
-          </div>
-          {nestedContent}
         </div>
+        {nestedContent}
       </div>
       <AlertDialog open={showDeleteDialog}>
         <AlertDialogContent>

--- a/src/components/CommentComponent.tsx
+++ b/src/components/CommentComponent.tsx
@@ -1,10 +1,11 @@
 import { getDateDifferenceString } from "@/utils/dateUtils";
 import { PopulatedComment } from "@/utils/types/comment";
-import { ChatBubbleLeftEllipsisIcon, EllipsisHorizontalIcon, HeartIcon } from "@heroicons/react/24/outline";
+import { MessageSquare, Ellipsis, Heart } from "lucide-react";
 import { HeartIcon as FilledHeartIcon } from "@heroicons/react/24/solid";
 import MarkdownRenderer from "./MarkdownRenderer";
 import MarkdownIt from "markdown-it";
 import { ReactNode, useState } from "react";
+import colors from "tailwindcss/colors";
 
 type CommentComponentProps = {
   className?: string;
@@ -61,9 +62,9 @@ export default function CommentComponent(props: CommentComponentProps) {
   }
 
   const bottomRow = [
-    { label: likes.toString(), Icon: liked ? FilledHeartIcon : HeartIcon, onClick: handleLikeClick },
-    { label: 'Reply', Icon: ChatBubbleLeftEllipsisIcon, onClick: onReplyClick },
-    { label: '', Icon: EllipsisHorizontalIcon, onClick: () => {} }
+    { label: likes.toString(), icon: liked ? <Heart className="text-red-500" fill={colors.red[500]} /> : <Heart />, onClick: handleLikeClick },
+    { label: 'Reply', icon: <MessageSquare />, onClick: onReplyClick },
+    { label: '', icon: <Ellipsis />, onClick: () => {} }
   ];
 
   return (
@@ -87,7 +88,9 @@ export default function CommentComponent(props: CommentComponentProps) {
           {bottomRow.map((item, index) => item.onClick && (
             <div key={index} className="flex items-center gap-1.5 px-1">
               <button onClick={item.onClick}>
-                <item.Icon className="w-5 h-5" />
+                <div className="w-5 h-5 [&>*]:w-full [&>*]:h-full">
+                  {item.icon}
+                </div>
               </button>
               {item.label}
             </div>

--- a/src/components/CommentComponent.tsx
+++ b/src/components/CommentComponent.tsx
@@ -1,11 +1,9 @@
 import { getDateDifferenceString } from "@/utils/dateUtils";
 import { PopulatedComment } from "@/utils/types/comment";
 import { MessageSquare, Ellipsis, Heart } from "lucide-react";
-import { HeartIcon as FilledHeartIcon } from "@heroicons/react/24/solid";
 import MarkdownRenderer from "./MarkdownRenderer";
 import MarkdownIt from "markdown-it";
 import { ReactNode, useState } from "react";
-import colors from "tailwindcss/colors";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "./ui/dropdown-menu";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "./ui/alert-dialog";
 
@@ -35,7 +33,8 @@ export default function CommentComponent(props: CommentComponentProps) {
     content,
     date,
     likes: initialLikes,
-    liked: initialLiked
+    liked: initialLiked,
+    replyTo
   } = comment;
 
   const [likes, setLikes] = useState<number>(initialLikes);
@@ -72,17 +71,25 @@ export default function CommentComponent(props: CommentComponentProps) {
   }
 
   const bottomRow = [
-    { label: likes.toString(), icon: liked ? <Heart className="text-red-500" fill={colors.red[500]} /> : <Heart />, onClick: handleLikeClick },
-    { label: 'Reply', icon: <MessageSquare />, onClick: onReplyClick }
+    {
+      label: likes.toString(),
+      icon: liked ? <Heart className="text-red-500 fill-red-500" /> : <Heart />,
+      onClick: likeLoading ? undefined : handleLikeClick
+    },
+    ... replyTo ? [] : [{ 
+      label: 'Reply',
+      icon: <MessageSquare />,
+      onClick: onReplyClick
+    }]
   ];
 
   return (
     <>
       <div className="flex gap-2.5">
         <div>
-          <span className="w-6 h-6 bg-[#D9D9D9] rounded-full inline-block"/>
+          <span className="w-6 h-6 bg-focus-med-gray rounded-full inline-block"/>
         </div>
-        <div className={`flex-grow flex flex-col gap-2 text-[#636363] ${className}`}>
+        <div className={`flex-grow flex flex-col gap-2 text-focus-gray ${className}`}>
           <div className="flex items-center justify-between">
             <div className="font-bold text-black">
               {author ? `${author.lastName} Family` : 'Deleted User'}
@@ -95,9 +102,9 @@ export default function CommentComponent(props: CommentComponentProps) {
             parse={markdown => mdParser.render(markdown)}
           />
           <div className="flex items-center pt-2 gap-6 text-sm">
-            {bottomRow.map((item, index) => item.onClick && (
+            {bottomRow.map((item, index) => (
               <div key={index} className="flex items-center gap-1.5 px-1">
-                <button onClick={item.onClick}>
+                <button disabled={!item.onClick} onClick={item.onClick}>
                   <div className="w-5 h-5 [&>*]:w-full [&>*]:h-full">
                     {item.icon}
                   </div>

--- a/src/components/CommentComponent.tsx
+++ b/src/components/CommentComponent.tsx
@@ -3,16 +3,25 @@ import { PopulatedComment } from "@/utils/types/comment";
 import { ChatBubbleLeftEllipsisIcon, EllipsisHorizontalIcon, HeartIcon } from "@heroicons/react/24/outline";
 import MarkdownRenderer from "./MarkdownRenderer";
 import MarkdownIt from "markdown-it";
+import { ReactNode } from "react";
 
 type CommentComponentProps = {
   className?: string;
   comment: PopulatedComment;
+  onReplyClick?: () => void;
+  nestedContent?: ReactNode;
 };
 
 export default function CommentComponent(props: CommentComponentProps) {
   const mdParser = new MarkdownIt();
 
-  const { className = '', comment } = props;
+  const {
+    className = '',
+    comment,
+    onReplyClick,
+    nestedContent
+  } = props;
+  
   const {
     author,
     content,
@@ -21,9 +30,9 @@ export default function CommentComponent(props: CommentComponentProps) {
   } = comment;
 
   const bottomRow = [
-    { label: likes.toString(), Icon: HeartIcon },
-    { label: 'Reply', Icon: ChatBubbleLeftEllipsisIcon },
-    { label: '', Icon: EllipsisHorizontalIcon }
+    { label: likes.toString(), Icon: HeartIcon, onClick: () => {} },
+    { label: 'Reply', Icon: ChatBubbleLeftEllipsisIcon, onClick: onReplyClick },
+    { label: '', Icon: EllipsisHorizontalIcon, onClick: () => {} }
   ];
 
   return (
@@ -44,15 +53,16 @@ export default function CommentComponent(props: CommentComponentProps) {
           parse={markdown => mdParser.render(markdown)}
         />
         <div className="flex items-center pt-2 gap-6 text-sm">
-          {bottomRow.map((item, index) => (
+          {bottomRow.map((item, index) => item.onClick && (
             <div key={index} className="flex items-center gap-1.5 px-1">
-              <button>
+              <button onClick={item.onClick}>
                 <item.Icon className="w-5 h-5" />
               </button>
               {item.label}
             </div>
           ))}
         </div>
+        {nestedContent}
       </div>
     </div>
   );

--- a/src/components/CreatePostModal.tsx
+++ b/src/components/CreatePostModal.tsx
@@ -14,7 +14,6 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover"
 import { useToast } from "@/hooks/use-toast";
-import { Types } from "mongoose";
 import { MDXEditorMethods } from "@mdxeditor/editor";
 import { cn, countNonMarkdownCharacters } from "@/lib/utils";
 

--- a/src/components/CreatePostModal.tsx
+++ b/src/components/CreatePostModal.tsx
@@ -6,7 +6,7 @@ import { getDisabilities } from "@/server/db/actions/DisabilityActions";
 import { Disability } from "@/utils/types/disability";
 import Tag from "./Tag";
 import dynamic from 'next/dynamic'
-import { MAX_POST_TITLE_LEN, MAX_POST_CONTENT_LEN, MAX_POST_DISABILITY_TAGS } from "@/utils/consts";
+import { MAX_POST_TITLE_LEN, MAX_POST_CONTENT_LEN, MAX_POST_DISABILITY_TAGS, USER_ID } from "@/utils/consts";
 import { ChevronDown, Check, X, ChevronUp } from "lucide-react";
 import {
   Popover,
@@ -84,7 +84,7 @@ export default function CreatePostModal( props: CreatePostModalProps ) {
       if (validateSubmission()) {
         setIsSubmitting(true);
         const formattedData = {
-          author: (new Types.ObjectId()).toString(), // TODO: replace with actual userid 
+          author: USER_ID, // TODO: replace with actual userid 
           title: postData.title,
           content: postData.content.trim(),
           tags: postData.tags.map((tag) => tag._id)

--- a/src/components/PostComponent.tsx
+++ b/src/components/PostComponent.tsx
@@ -132,7 +132,7 @@ export default function PostComponent(props: PostComponentProps) {
                 <Ellipsis className="w-6 h-6" />
               </DropdownMenuTrigger>
               <DropdownMenuContent side="bottom" align="end">
-                { onDeleteClick && <DropdownMenuItem onClick={() => setShowDeleteDialog(true)}>Delete</DropdownMenuItem> }
+                {onDeleteClick && <DropdownMenuItem onClick={() => setShowDeleteDialog(true)}>Delete</DropdownMenuItem>}
               </DropdownMenuContent>
             </DropdownMenu>
           )

--- a/src/components/PostComponent.tsx
+++ b/src/components/PostComponent.tsx
@@ -2,14 +2,14 @@
 
 import { PopulatedPost } from "@/utils/types/post";
 import Tag from "./Tag";
-import { BookmarkIcon, ChatBubbleLeftEllipsisIcon, EllipsisHorizontalIcon, HeartIcon } from "@heroicons/react/24/outline";
-import { HeartIcon as FilledHeartIcon } from "@heroicons/react/24/solid";
+import { Bookmark, MessageSquare, Ellipsis, Heart } from "lucide-react";
 import { getDateDifferenceString } from "@/utils/dateUtils";
 import MarkdownIt from "markdown-it";
 import MarkdownRenderer from "./MarkdownRenderer";
 import { cn } from "@/lib/utils";
 import Link from "next/link";
 import { useState } from "react";
+import colors from "tailwindcss/colors";
 
 type PostComponentProps = {
   className?: string;
@@ -69,9 +69,9 @@ export default function PostComponent(props: PostComponentProps) {
   }
 
   const bottomRow = [
-    { label: likes.toString(), Icon: liked ? FilledHeartIcon : HeartIcon, onClick: handleLikeClick },
-    { label: comments.toString(), Icon: ChatBubbleLeftEllipsisIcon },
-    { label: 'Save Post', Icon: BookmarkIcon }
+    { label: likes.toString(), icon: liked ? <Heart className="text-red-500" fill={colors.red[500]} /> : <Heart />, onClick: handleLikeClick },
+    { label: comments.toString(), icon: <MessageSquare /> },
+    { label: 'Save Post', icon: <Bookmark /> }
   ];
 
   const reactContent = (
@@ -88,7 +88,7 @@ export default function PostComponent(props: PostComponentProps) {
         {
           !clickable && (
             <button>
-              <EllipsisHorizontalIcon className="w-6 h-6" />
+              <Ellipsis className="w-6 h-6" />
             </button>
           )
         }
@@ -105,7 +105,9 @@ export default function PostComponent(props: PostComponentProps) {
         {bottomRow.map((item, index) => (
           <div key={`${post._id}-${index}`} className="flex items-center gap-1.5 px-2">
             <button onClick={item.onClick}>
-              <item.Icon className="w-6 h-6" />
+              <div className="w-6 h-6 [&>*]:w-full [&>*]:h-full">
+                {item.icon}
+              </div>
             </button>
             {item.label}
           </div>

--- a/src/components/PostComponent.tsx
+++ b/src/components/PostComponent.tsx
@@ -16,6 +16,7 @@ type PostComponentProps = {
   post: PopulatedPost;
   clickable?: boolean;
   onLikeClick?: (liked: boolean) => Promise<void>;
+  onSaveClick?: (saved: boolean) => Promise<void>;
 };
 
 export default function PostComponent(props: PostComponentProps) {
@@ -27,7 +28,8 @@ export default function PostComponent(props: PostComponentProps) {
     className = '',
     post,
     clickable = false,
-    onLikeClick
+    onLikeClick,
+    onSaveClick
   } = props;
 
   const {
@@ -38,12 +40,15 @@ export default function PostComponent(props: PostComponentProps) {
     tags,
     likes: initialLikes,
     liked: initialLiked,
+    saved: initialSaved,
     comments
   } = post;
 
   const [likes, setLikes] = useState<number>(initialLikes);
   const [liked, setLiked] = useState<boolean>(initialLiked);
   const [likeLoading, setLikeLoading] = useState<boolean>(false);
+  const [saved, setSaved] = useState<boolean>(initialSaved);
+  const [saveLoading, setSaveLoading] = useState<boolean>(false);
 
   async function handleLikeClick() {
     if (likeLoading) return;
@@ -68,10 +73,26 @@ export default function PostComponent(props: PostComponentProps) {
     }
   }
 
+  async function handleSaveClick() {
+    if (saveLoading) return;
+    setSaved(saved => !saved);
+
+    if (onSaveClick) {
+      setSaveLoading(true);
+      try {
+        await onSaveClick(saved);
+      } catch (err) {
+        setSaved(saved);
+      } finally {
+        setSaveLoading(false);
+      }
+    }
+  }
+
   const bottomRow = [
     { label: likes.toString(), icon: liked ? <Heart className="text-red-500" fill={colors.red[500]} /> : <Heart />, onClick: handleLikeClick },
     { label: comments.toString(), icon: <MessageSquare /> },
-    { label: 'Save Post', icon: <Bookmark /> }
+    { label: saved ? 'Saved Post' : 'Save Post', icon: saved ? <Bookmark fill={'#636363'} /> : <Bookmark />, onClick: handleSaveClick }
   ];
 
   const reactContent = (

--- a/src/components/PostComponent.tsx
+++ b/src/components/PostComponent.tsx
@@ -9,7 +9,6 @@ import MarkdownRenderer from "./MarkdownRenderer";
 import { cn } from "@/lib/utils";
 import Link from "next/link";
 import { useState } from "react";
-import colors from "tailwindcss/colors";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "./ui/dropdown-menu";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "./ui/alert-dialog";
 
@@ -109,16 +108,27 @@ export default function PostComponent(props: PostComponentProps) {
   }
 
   const bottomRow = [
-    { label: likes.toString(), icon: liked ? <Heart className="text-red-500" fill={colors.red[500]} /> : <Heart />, onClick: handleLikeClick },
-    { label: comments.toString(), icon: <MessageSquare /> },
-    { label: saved ? 'Saved Post' : 'Save Post', icon: saved ? <Bookmark fill={'#636363'} /> : <Bookmark />, onClick: handleSaveClick }
+    {
+      label: likes.toString(),
+      icon: liked ? <Heart className="text-red-500 fill-red-500" /> : <Heart />,
+      onClick: likeLoading ? undefined : handleLikeClick
+    },
+    {
+      label: comments.toString(),
+      icon: <MessageSquare />
+    },
+    {
+      label: saved ? 'Saved Post' : 'Save Post',
+      icon: saved ? <Bookmark className="fill-focus-gray" /> : <Bookmark />,
+      onClick: saveLoading ? undefined : handleSaveClick
+    }
   ];
 
   const reactContent = (
     <>
       <div className="flex items-center justify-between text-sm">
         <div className="flex items-center gap-2">
-          <span className="w-6 h-6 bg-[#D9D9D9] rounded-full inline-block"/>
+          <span className="w-6 h-6 bg-focus-med-gray rounded-full inline-block"/>
           {author ? `${author.lastName} Family` : 'Deleted User'}
         </div>
         <p suppressHydrationWarning>{getDateDifferenceString(new Date(), date)}</p>
@@ -149,7 +159,7 @@ export default function PostComponent(props: PostComponentProps) {
       <div className="flex items-center pt-2 gap-6">
         {bottomRow.map((item, index) => (
           <div key={`${post._id}-${index}`} className="flex items-center gap-1.5 px-2">
-            <button onClick={item.onClick}>
+            <button disabled={!item.onClick} onClick={item.onClick}>
               <div className="w-6 h-6 [&>*]:w-full [&>*]:h-full">
                 {item.icon}
               </div>
@@ -181,7 +191,7 @@ export default function PostComponent(props: PostComponentProps) {
   );
 
   const classes = cn(
-    'flex flex-col gap-2 text-[#636363] rounded-lg',
+    'flex flex-col gap-2 text-focus-gray rounded-lg',
     clickable && 'cursor-pointer hover:bg-gray-100 p-4',
     className
   );

--- a/src/components/PostComponent.tsx
+++ b/src/components/PostComponent.tsx
@@ -56,7 +56,7 @@ export default function PostComponent(props: PostComponentProps) {
   const [deleteLoading, setDeleteLoading] = useState<boolean>(false);
 
   async function handleLikeClick() {
-    if (likeLoading) return;
+    if (likeLoading || clickable) return;
 
     if (liked) {
       setLikes(likes => likes - 1);
@@ -79,7 +79,7 @@ export default function PostComponent(props: PostComponentProps) {
   }
 
   async function handleSaveClick() {
-    if (saveLoading) return;
+    if (saveLoading || clickable) return;
     setSaved(saved => !saved);
 
     if (onSaveClick) {

--- a/src/components/PostComponent.tsx
+++ b/src/components/PostComponent.tsx
@@ -134,7 +134,7 @@ export default function PostComponent(props: PostComponentProps) {
     <>
       <div className="flex items-center justify-between text-sm">
         <div className="flex items-center gap-2">
-          <span className="w-6 h-6 bg-focus-med-gray rounded-full inline-block"/>
+          <span className="w-6 h-6 bg-theme-med-gray rounded-full inline-block"/>
           {author ? `${author.lastName} Family` : 'Deleted User'}
         </div>
         <p suppressHydrationWarning>{getDateDifferenceString(new Date(), date)}</p>

--- a/src/components/PostPage/CommentInputComponent.tsx
+++ b/src/components/PostPage/CommentInputComponent.tsx
@@ -1,0 +1,39 @@
+import { PaperAirplaneIcon } from "@heroicons/react/24/solid";
+import { useState } from "react";
+
+type CommentInputComponentProps = {
+  className?: string;
+  placeholder?: string;
+  onSubmit: (value: string) => Promise<boolean>;
+}; 
+
+export default function CommentInputComponent(props: CommentInputComponentProps) {
+  const { className = '', placeholder = '', onSubmit } = props;
+  const [value, setValue] = useState<string>('');
+  const [loading, setLoading] = useState<boolean>(false);
+
+  async function handleSubmit() {
+    if (loading) return;
+    setLoading(true);
+    const success = await onSubmit(value);
+    if (success) {
+      setValue('');
+    }
+    setLoading(false);
+  }
+
+  return (
+    <div className={`flex items-center bg-[#F3F3F3] rounded-full ${className}`}>
+      <input
+        className="flex-grow pl-5 pr-3 py-2 bg-transparent outline-none select-none text-black"
+        placeholder={placeholder}
+        value={value}
+        onChange={e => setValue(e.target.value)}
+        onKeyDown={e => e.key === 'Enter' && value !== '' && handleSubmit()}
+      />
+      <button className={value === '' ? 'hidden' : ''} onClick={handleSubmit}>
+        <PaperAirplaneIcon className="w-6 h-6 text-blue mr-4" />
+      </button>
+    </div>
+  );
+}

--- a/src/components/PostPage/CommentInputComponent.tsx
+++ b/src/components/PostPage/CommentInputComponent.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 type CommentInputComponentProps = {
   className?: string;
   placeholder?: string;
-  onSubmit: (value: string) => Promise<boolean>;
+  onSubmit: (value: string) => Promise<void>;
 }; 
 
 export default function CommentInputComponent(props: CommentInputComponentProps) {
@@ -15,10 +15,12 @@ export default function CommentInputComponent(props: CommentInputComponentProps)
   async function handleSubmit() {
     if (loading) return;
     setLoading(true);
-    const success = await onSubmit(value);
-    if (success) {
+
+    try {
+      await onSubmit(value);
       setValue('');
-    }
+    } catch (err) {}
+
     setLoading(false);
   }
 

--- a/src/components/PostPage/CommentInputComponent.tsx
+++ b/src/components/PostPage/CommentInputComponent.tsx
@@ -25,7 +25,7 @@ export default function CommentInputComponent(props: CommentInputComponentProps)
   }
 
   return (
-    <div className={`flex items-center bg-[#F3F3F3] rounded-full ${className}`}>
+    <div className={`flex items-center bg-focus-light-gray rounded-full ${className}`}>
       <input
         className="flex-grow pl-5 pr-3 py-2 bg-transparent outline-none select-none text-black"
         placeholder={placeholder}

--- a/src/components/PostPage/CommentInputComponent.tsx
+++ b/src/components/PostPage/CommentInputComponent.tsx
@@ -25,7 +25,7 @@ export default function CommentInputComponent(props: CommentInputComponentProps)
   }
 
   return (
-    <div className={`flex items-center bg-focus-light-gray rounded-full ${className}`}>
+    <div className={`flex items-center bg-theme-lightgray rounded-full ${className}`}>
       <input
         className="flex-grow pl-5 pr-3 py-2 bg-transparent outline-none select-none text-black"
         placeholder={placeholder}

--- a/src/components/PostPage/CommentTreeContainer.tsx
+++ b/src/components/PostPage/CommentTreeContainer.tsx
@@ -65,11 +65,16 @@ export default function CommentTreeContainer(props: CommentTreeContainerProps) {
     }
   }
 
+  async function onDeleteClick(commentId: string) {
+    // TODO
+  }
+
   return (
     <CommentComponent
       comment={parentComment}
       onReplyClick={onReplyClick}
       onLikeClick={liked => onLikeClick(parentComment._id, liked)}
+      onDeleteClick={parentComment.author?._id === authUser._id ? () => onDeleteClick(parentComment._id) : undefined}
       nestedContent={(
         <div className="mt-2 flex flex-col gap-2">
           {showReplyInput && <CommentInputComponent
@@ -81,6 +86,7 @@ export default function CommentTreeContainer(props: CommentTreeContainerProps) {
             key={comment._id}
             comment={comment}
             onLikeClick={liked => onLikeClick(comment._id, liked)}
+            onDeleteClick={comment.author?._id === authUser._id ? () => onDeleteClick(comment._id) : undefined}
           />)}
         </div>
       )}

--- a/src/components/PostPage/CommentTreeContainer.tsx
+++ b/src/components/PostPage/CommentTreeContainer.tsx
@@ -3,17 +3,17 @@ import CommentComponent from "../CommentComponent";
 import CommentInputComponent from "./CommentInputComponent";
 import { useState } from "react";
 import { createComment } from "@/server/db/actions/CommentActions";
-
-const dummyId = '000000000000000000000000';
+import { User } from "@/utils/types/user";
 
 type CommentTreeContainerProps = {
-  postId: string,
-  parentComment: PopulatedComment,
-  childComments: PopulatedComment[]
+  postId: string;
+  parentComment: PopulatedComment;
+  childComments: PopulatedComment[];
+  authUser: User;
 };
 
 export default function CommentTreeContainer(props: CommentTreeContainerProps) {
-  const { postId, parentComment: initialParentComment, childComments: initialChildComments } = props;
+  const { postId, parentComment: initialParentComment, childComments: initialChildComments, authUser } = props;
   const [parentComment, setParentComment] = useState<PopulatedComment>(initialParentComment);
   const [childComments, setChildComments] = useState<PopulatedComment[]>(initialChildComments);
   const [showReplyInput, setShowReplyInput] = useState<boolean>(false);
@@ -24,7 +24,7 @@ export default function CommentTreeContainer(props: CommentTreeContainerProps) {
 
   async function onReplySubmit(replyBody: string) {
     const replyInput: CommentInput = {
-      author: parentComment.author?._id || dummyId,
+      author: authUser._id,
       content: replyBody,
       post: postId,
       date: new Date(),
@@ -32,8 +32,8 @@ export default function CommentTreeContainer(props: CommentTreeContainerProps) {
     };
     const reply: PopulatedComment = {
       ...commentSchema.parse(replyInput),
-      _id: dummyId,
-      author: parentComment.author,
+      _id: '',
+      author: authUser,
       post: postId,
       replyTo: parentComment._id
     };
@@ -42,7 +42,7 @@ export default function CommentTreeContainer(props: CommentTreeContainerProps) {
     try {
       const replyServer: PopulatedComment = {
         ...await createComment(replyInput),
-        author: parentComment.author,
+        author: authUser,
         post: postId,
         replyTo: parentComment._id
       };

--- a/src/components/PostPage/CommentTreeContainer.tsx
+++ b/src/components/PostPage/CommentTreeContainer.tsx
@@ -1,0 +1,75 @@
+import { CommentInput, commentSchema, PopulatedComment } from "@/utils/types/comment";
+import CommentComponent from "../CommentComponent";
+import CommentInputComponent from "./CommentInputComponent";
+import { useState } from "react";
+import { createComment } from "@/server/db/actions/CommentActions";
+
+const dummyId = '000000000000000000000000';
+
+type CommentTreeContainerProps = {
+  postId: string,
+  parentComment: PopulatedComment,
+  childComments: PopulatedComment[]
+};
+
+export default function CommentTreeContainer(props: CommentTreeContainerProps) {
+  const { postId, parentComment: initialParentComment, childComments: initialChildComments } = props;
+  const [parentComment, setParentComment] = useState<PopulatedComment>(initialParentComment);
+  const [childComments, setChildComments] = useState<PopulatedComment[]>(initialChildComments);
+  const [showReplyInput, setShowReplyInput] = useState<boolean>(false);
+
+  function onReplyClick() {
+    setShowReplyInput(!showReplyInput);
+  }
+
+  async function onReplySubmit(replyBody: string) {
+    const replyInput: CommentInput = {
+      author: parentComment.author?._id || dummyId,
+      content: replyBody,
+      post: postId,
+      date: new Date(),
+      replyTo: parentComment._id
+    };
+    const reply: PopulatedComment = {
+      ...commentSchema.parse(replyInput),
+      _id: dummyId,
+      author: parentComment.author,
+      post: postId,
+      replyTo: parentComment._id
+    };
+    setChildComments(childComments => [reply, ...childComments]);
+
+    try {
+      const replyServer: PopulatedComment = {
+        ...await createComment(replyInput),
+        author: parentComment.author,
+        post: postId,
+        replyTo: parentComment._id
+      };
+      setChildComments(childComments => [replyServer, ...childComments.slice(1)]);
+      setShowReplyInput(false);
+      return true;
+    } catch (err) {
+      console.error('Failed to add comment:', err);
+      setChildComments(childComments => childComments.slice(1));
+      return false;
+    }
+  }
+
+  return (
+    <CommentComponent
+      comment={parentComment}
+      onReplyClick={onReplyClick}
+      nestedContent={(
+        <div className="mt-2 flex flex-col gap-2">
+          {showReplyInput && <CommentInputComponent
+            className="mb-2"
+            placeholder="Reply to comment"
+            onSubmit={onReplySubmit}
+          />}
+          {childComments.map(comment => <CommentComponent key={comment._id} comment={comment} />)}
+        </div>
+      )}
+    />
+  );
+}

--- a/src/components/PostPage/CommentTreeContainer.tsx
+++ b/src/components/PostPage/CommentTreeContainer.tsx
@@ -58,10 +58,15 @@ export default function CommentTreeContainer(props: CommentTreeContainerProps) {
   }
 
   async function onLikeClick(commentId: string, liked: boolean) {
-    if (liked) {
-      await deleteCommentLike(authUser._id, commentId);
-    } else {
-      await createCommentLike(authUser._id, commentId);
+    try {
+      if (liked) {
+        await deleteCommentLike(authUser._id, commentId);
+      } else {
+        await createCommentLike(authUser._id, commentId);
+      }
+    } catch (err) {
+      console.error(`Failed to ${liked ? 'dislike' : 'like'} comment:`, err);
+      throw err;
     }
   }
 

--- a/src/components/PostPage/PostCommentsContainer.tsx
+++ b/src/components/PostPage/PostCommentsContainer.tsx
@@ -10,7 +10,8 @@ import { useState } from "react";
 import CommentInputComponent from "./CommentInputComponent";
 import CommentTreeContainer from "./CommentTreeContainer";
 import { User } from "@/utils/types/user";
-import { createPostLike, createPostSave, deletePostLike, deletePostSave } from "@/server/db/actions/PostActions";
+import { createPostLike, createPostSave, deletePost, deletePostLike, deletePostSave } from "@/server/db/actions/PostActions";
+import { useRouter } from "next/navigation";
 
 function buildChildCommentsMap(comments: PopulatedComment[]) {
   const map = new Map<string, PopulatedComment[]>();
@@ -32,6 +33,8 @@ type PostCommentsContainerProps = {
 
 export default function PostCommentsContainer(props: PostCommentsContainerProps) {
   const { post, comments: initialComments, authUser } = props;
+
+  const router = useRouter();
 
   const [parentComments, setParentComments] = useState<PopulatedComment[]>(
     initialComments.filter(comment => comment.replyTo === null)
@@ -89,6 +92,16 @@ export default function PostCommentsContainer(props: PostCommentsContainerProps)
     }
   }
 
+  async function onPostDeleteClick() {
+    try {
+      await deletePost(post._id);
+      router.push('/');
+    } catch (err) {
+      console.error('Failed to delete post:', err);
+      throw err;
+    }
+  }
+
   return (
     <>
       <div className="mx-16 my-4 text-lg text-[#686868]">
@@ -101,6 +114,7 @@ export default function PostCommentsContainer(props: PostCommentsContainerProps)
           post={post}
           onLikeClick={onPostLikeClick}
           onSaveClick={onPostSaveClick}
+          onDeleteClick={post.author?._id === authUser._id ? onPostDeleteClick : undefined}
         />
         <CommentInputComponent
           placeholder="Add comment"

--- a/src/components/PostPage/PostCommentsContainer.tsx
+++ b/src/components/PostPage/PostCommentsContainer.tsx
@@ -12,6 +12,7 @@ import CommentTreeContainer from "./CommentTreeContainer";
 import { User } from "@/utils/types/user";
 import { createPostLike, createPostSave, deletePost, deletePostLike, deletePostSave } from "@/server/db/actions/PostActions";
 import { useRouter } from "next/navigation";
+import { useToast } from "@/hooks/use-toast";
 
 function buildChildCommentsMap(comments: PopulatedComment[]) {
   const map = new Map<string, PopulatedComment[]>();
@@ -35,6 +36,7 @@ export default function PostCommentsContainer(props: PostCommentsContainerProps)
   const { post, comments: initialComments, authUser } = props;
 
   const router = useRouter();
+  const { toast } = useToast();
 
   const [parentComments, setParentComments] = useState<PopulatedComment[]>(
     initialComments.filter(comment => comment.replyTo === null)
@@ -106,6 +108,10 @@ export default function PostCommentsContainer(props: PostCommentsContainerProps)
     try {
       await deletePost(post._id);
       router.push('/');
+      toast({
+        title: "Post successfully deleted",
+        description: "Your post has been successfully deleted from the community."
+      });
     } catch (err) {
       console.error('Failed to delete post:', err);
       throw err;

--- a/src/components/PostPage/PostCommentsContainer.tsx
+++ b/src/components/PostPage/PostCommentsContainer.tsx
@@ -77,18 +77,28 @@ export default function PostCommentsContainer(props: PostCommentsContainerProps)
   }
 
   async function onPostLikeClick(liked: boolean) {
-    if (liked) {
-      await deletePostLike(authUser._id, post._id);
-    } else {
-      await createPostLike(authUser._id, post._id);
+    try {
+      if (liked) {
+        await deletePostLike(authUser._id, post._id);
+      } else {
+        await createPostLike(authUser._id, post._id);
+      }
+    } catch (err) {
+      console.error(`Failed to ${liked ? 'dislike' : 'like'} post:`, err);
+      throw err;
     }
   }
 
   async function onPostSaveClick(saved: boolean) {
-    if (saved) {
-      await deletePostSave(authUser._id, post._id);
-    } else {
-      await createPostSave(authUser._id, post._id);
+    try {
+      if (saved) {
+        await deletePostSave(authUser._id, post._id);
+      } else {
+        await createPostSave(authUser._id, post._id);
+      }
+    } catch (err) {
+      console.error(`Failed to ${saved ? 'unsave' : 'save'} post`, err);
+      throw err;
     }
   }
 

--- a/src/components/PostPage/PostCommentsContainer.tsx
+++ b/src/components/PostPage/PostCommentsContainer.tsx
@@ -10,7 +10,7 @@ import { useState } from "react";
 import CommentInputComponent from "./CommentInputComponent";
 import CommentTreeContainer from "./CommentTreeContainer";
 import { User } from "@/utils/types/user";
-import { createPostLike, deletePostLike } from "@/server/db/actions/PostActions";
+import { createPostLike, createPostSave, deletePostLike, deletePostSave } from "@/server/db/actions/PostActions";
 
 function buildChildCommentsMap(comments: PopulatedComment[]) {
   const map = new Map<string, PopulatedComment[]>();
@@ -81,6 +81,14 @@ export default function PostCommentsContainer(props: PostCommentsContainerProps)
     }
   }
 
+  async function onPostSaveClick(saved: boolean) {
+    if (saved) {
+      await deletePostSave(authUser._id, post._id);
+    } else {
+      await createPostSave(authUser._id, post._id);
+    }
+  }
+
   return (
     <>
       <div className="mx-16 my-4 text-lg text-[#686868]">
@@ -92,6 +100,7 @@ export default function PostCommentsContainer(props: PostCommentsContainerProps)
         <PostComponent
           post={post}
           onLikeClick={onPostLikeClick}
+          onSaveClick={onPostSaveClick}
         />
         <CommentInputComponent
           placeholder="Add comment"

--- a/src/components/PostPage/PostCommentsContainer.tsx
+++ b/src/components/PostPage/PostCommentsContainer.tsx
@@ -9,8 +9,7 @@ import Link from "next/link";
 import { useState } from "react";
 import CommentInputComponent from "./CommentInputComponent";
 import CommentTreeContainer from "./CommentTreeContainer";
-
-const dummyId = '000000000000000000000000';
+import { User } from "@/utils/types/user";
 
 function buildChildCommentsMap(comments: PopulatedComment[]) {
   const map = new Map<string, PopulatedComment[]>();
@@ -25,12 +24,13 @@ function buildChildCommentsMap(comments: PopulatedComment[]) {
 }
 
 type PostCommentsContainerProps = {
-  post: PopulatedPost,
-  initialComments: PopulatedComment[]
+  post: PopulatedPost;
+  initialComments: PopulatedComment[];
+  authUser: User;
 };
 
 export default function PostCommentsContainer(props: PostCommentsContainerProps) {
-  const { post, initialComments } = props;
+  const { post, initialComments, authUser } = props;
 
   const [parentComments, setParentComments] = useState<PopulatedComment[]>(
     initialComments.filter(comment => comment.replyTo === null)
@@ -41,15 +41,15 @@ export default function PostCommentsContainer(props: PostCommentsContainerProps)
 
   async function onNewCommentSubmit(newCommentBody: string) {
     const newCommentInput: CommentInput = {
-      author: post.author?._id || dummyId,
+      author: authUser._id,
       content: newCommentBody,
       post: post._id,
       date: new Date()
     };
     const newComment: PopulatedComment = {
       ...commentSchema.parse(newCommentInput),
-      _id: dummyId,
-      author: post.author,
+      _id: '',
+      author: authUser,
       post: post._id,
       replyTo: null
     };
@@ -58,7 +58,7 @@ export default function PostCommentsContainer(props: PostCommentsContainerProps)
     try {
       const newCommentServer: PopulatedComment = {
         ...await createComment(newCommentInput),
-        author: post.author,
+        author: authUser,
         post: post._id,
         replyTo: null
       };
@@ -90,6 +90,7 @@ export default function PostCommentsContainer(props: PostCommentsContainerProps)
             postId={post._id}
             parentComment={comment}
             childComments={childComments.get(comment._id) || []}
+            authUser={authUser}
           />
         ))}
       </div>

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,141 @@
+"use client"
+
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+
+const AlertDialog = AlertDialogPrimitive.Root
+
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger
+
+const AlertDialogPortal = AlertDialogPrimitive.Portal
+
+const AlertDialogOverlay = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName
+
+const AlertDialogContent = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-neutral-200 bg-white p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg dark:border-neutral-800 dark:bg-neutral-950",
+        className
+      )}
+      {...props}
+    />
+  </AlertDialogPortal>
+))
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName
+
+const AlertDialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+AlertDialogHeader.displayName = "AlertDialogHeader"
+
+const AlertDialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+AlertDialogFooter.displayName = "AlertDialogFooter"
+
+const AlertDialogTitle = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold", className)}
+    {...props}
+  />
+))
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName
+
+const AlertDialogDescription = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-neutral-500 dark:text-neutral-400", className)}
+    {...props}
+  />
+))
+AlertDialogDescription.displayName =
+  AlertDialogPrimitive.Description.displayName
+
+const AlertDialogAction = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Action
+    ref={ref}
+    className={cn(buttonVariants(), className)}
+    {...props}
+  />
+))
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName
+
+const AlertDialogCancel = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Cancel
+    ref={ref}
+    className={cn(
+      buttonVariants({ variant: "outline" }),
+      "mt-2 sm:mt-0",
+      className
+    )}
+    {...props}
+  />
+))
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,57 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-neutral-950 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 dark:focus-visible:ring-neutral-300",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-neutral-900 text-neutral-50 shadow hover:bg-neutral-900/90 dark:bg-neutral-50 dark:text-neutral-900 dark:hover:bg-neutral-50/90",
+        destructive:
+          "bg-red-500 text-neutral-50 shadow-sm hover:bg-red-500/90 dark:bg-red-900 dark:text-neutral-50 dark:hover:bg-red-900/90",
+        outline:
+          "border border-neutral-200 bg-white shadow-sm hover:bg-neutral-100 hover:text-neutral-900 dark:border-neutral-800 dark:bg-neutral-950 dark:hover:bg-neutral-800 dark:hover:text-neutral-50",
+        secondary:
+          "bg-neutral-100 text-neutral-900 shadow-sm hover:bg-neutral-100/80 dark:bg-neutral-800 dark:text-neutral-50 dark:hover:bg-neutral-800/80",
+        ghost: "hover:bg-neutral-100 hover:text-neutral-900 dark:hover:bg-neutral-800 dark:hover:text-neutral-50",
+        link: "text-neutral-900 underline-offset-4 hover:underline dark:text-neutral-50",
+      },
+      size: {
+        default: "h-9 px-4 py-2",
+        sm: "h-8 rounded-md px-3 text-xs",
+        lg: "h-10 rounded-md px-8",
+        icon: "h-9 w-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button"
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Button.displayName = "Button"
+
+export { Button, buttonVariants }

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,205 @@
+"use client"
+
+import * as React from "react"
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
+import {
+  CheckIcon,
+  ChevronRightIcon,
+  DotFilledIcon,
+} from "@radix-ui/react-icons"
+
+import { cn } from "@/lib/utils"
+
+const DropdownMenu = DropdownMenuPrimitive.Root
+
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
+
+const DropdownMenuGroup = DropdownMenuPrimitive.Group
+
+const DropdownMenuPortal = DropdownMenuPrimitive.Portal
+
+const DropdownMenuSub = DropdownMenuPrimitive.Sub
+
+const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup
+
+const DropdownMenuSubTrigger = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
+    inset?: boolean
+  }
+>(({ className, inset, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-neutral-100 data-[state=open]:bg-neutral-100 dark:focus:bg-neutral-800 dark:data-[state=open]:bg-neutral-800",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <ChevronRightIcon className="ml-auto h-4 w-4" />
+  </DropdownMenuPrimitive.SubTrigger>
+))
+DropdownMenuSubTrigger.displayName =
+  DropdownMenuPrimitive.SubTrigger.displayName
+
+const DropdownMenuSubContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubContent
+    ref={ref}
+    className={cn(
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border border-neutral-200 bg-white p-1 text-neutral-950 shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-50",
+      className
+    )}
+    {...props}
+  />
+))
+DropdownMenuSubContent.displayName =
+  DropdownMenuPrimitive.SubContent.displayName
+
+const DropdownMenuContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border border-neutral-200 bg-white p-1 text-neutral-950 shadow-md dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-50",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+))
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
+
+const DropdownMenuItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-neutral-100 focus:text-neutral-900 data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0 dark:focus:bg-neutral-800 dark:focus:text-neutral-50",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  />
+))
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName
+
+const DropdownMenuCheckboxItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
+>(({ className, children, checked, ...props }, ref) => (
+  <DropdownMenuPrimitive.CheckboxItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-neutral-100 focus:text-neutral-900 data-[disabled]:pointer-events-none data-[disabled]:opacity-50 dark:focus:bg-neutral-800 dark:focus:text-neutral-50",
+      className
+    )}
+    checked={checked}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <CheckIcon className="h-4 w-4" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.CheckboxItem>
+))
+DropdownMenuCheckboxItem.displayName =
+  DropdownMenuPrimitive.CheckboxItem.displayName
+
+const DropdownMenuRadioItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
+>(({ className, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.RadioItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-neutral-100 focus:text-neutral-900 data-[disabled]:pointer-events-none data-[disabled]:opacity-50 dark:focus:bg-neutral-800 dark:focus:text-neutral-50",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <DotFilledIcon className="h-4 w-4 fill-current" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.RadioItem>
+))
+DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName
+
+const DropdownMenuLabel = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Label
+    ref={ref}
+    className={cn(
+      "px-2 py-1.5 text-sm font-semibold",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  />
+))
+DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName
+
+const DropdownMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-neutral-100 dark:bg-neutral-800", className)}
+    {...props}
+  />
+))
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName
+
+const DropdownMenuShortcut = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) => {
+  return (
+    <span
+      className={cn("ml-auto text-xs tracking-widest opacity-60", className)}
+      {...props}
+    />
+  )
+}
+DropdownMenuShortcut.displayName = "DropdownMenuShortcut"
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuGroup,
+  DropdownMenuPortal,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuRadioGroup,
+}

--- a/src/server/db/actions/CommentActions.ts
+++ b/src/server/db/actions/CommentActions.ts
@@ -161,7 +161,7 @@ export async function deleteCommentLike(userId: string, commentId: string): Prom
 }
 
 /**
- * Retrieves all comments under a post in descending order by date of creation, with authors populated and post and replyTo IDs nulled out.
+ * Retrieves all comments under a post in descending order by date of creation, with authors populated and post and replyTo IDs converted to strings.
  * @param postId - The ID of the post whose comments are to be retrieved.
  * @throws Will throw an error if the post is not found.
  * @returns A promise that resolves to an array of partially populated comment objects.
@@ -176,8 +176,8 @@ export async function getPostComments(postId: string): Promise<PopulatedComment[
 
   return comments.map(comment => {
     const res = comment.toObject();
-    res.post = null;
-    res.replyTo = null;
+    res.post = res.post.toString();
+    res.replyTo = res.replyTo?.toString() || null;
     return res;
   });
 }

--- a/src/server/db/actions/CommentActions.ts
+++ b/src/server/db/actions/CommentActions.ts
@@ -7,6 +7,7 @@ import dbConnect from "../dbConnect";
 import mongoose from "mongoose";
 import PostModel from "../models/PostModel";
 import UserModel from "../models/UserModel";
+import { revalidatePath } from "next/cache";
 
 /**
  * Creates a new comment in the database.
@@ -37,6 +38,7 @@ export async function createComment(comment: CommentInput): Promise<Comment> {
     throw new Error("Failed to create comment");
   } finally {
     session.endSession();
+    revalidatePath(`/posts/${comment.post}`);
   }
 }
 

--- a/src/server/db/actions/PostActions.ts
+++ b/src/server/db/actions/PostActions.ts
@@ -325,6 +325,7 @@ export async function createPostLike(userId: string, postId: string): Promise<Po
     throw error;
   } finally {
     session.endSession();
+    revalidatePath(`/posts/${postId}`);
   }
 }
 
@@ -362,5 +363,6 @@ export async function deletePostLike(userId: string, postId: string): Promise<vo
     throw error;
   } finally {
     session.endSession();
+    revalidatePath(`/posts/${postId}`);
   }
 }

--- a/src/server/db/actions/PostActions.ts
+++ b/src/server/db/actions/PostActions.ts
@@ -54,10 +54,13 @@ export async function getPopulatedPosts(authUserId: string): Promise<PopulatedPo
   
   const likes = await PostLikeModel.find({ user: authUserId });
   const likedIds = new Set(likes.map(like => like.post.toString()));
+  const saves = await PostSaveModel.find({ user: authUserId });
+  const savedIds = new Set(saves.map(save => save.post.toString()));
   
   return posts.map(post => {
     const res = post.toObject();
     res.liked = likedIds.has(post._id.toString());
+    res.saved = savedIds.has(post._id.toString());
     return res;
   });
 }
@@ -79,9 +82,9 @@ export async function getPost(id: string): Promise<Post> {
 }
 
 /**
- * Retrieves a single post from the database by its ID with its author and disability fields populated and like status specified.
+ * Retrieves a single post from the database by its ID with its author and disability fields populated and like and save statuses specified.
  * @param id - The ID of the post to retrieve.
- * @param authUserId - The ID of the currently authenticated user, to determine whether they have liked each post.
+ * @param authUserId - The ID of the currently authenticated user, to determine whether they have liked and/or saved each post.
  * @returns A promise that resolves to a populated post object containing author and disability objects (or null if they are not found)
  * @throws Will throw an error if the post is not found.
  */
@@ -105,9 +108,14 @@ export async function getPopulatedPost(id: string, authUserId: string): Promise<
     user: authUserId,
     post: post._id
   });
+  const save = await PostSaveModel.exists({
+    user: authUserId,
+    post: post._id
+  });
 
   const res = post.toObject();
   res.liked = !!like;
+  res.saved = !!save;
   return res;
 }
 

--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -1,3 +1,6 @@
 export const MAX_POST_TITLE_LEN = 100;
 export const MAX_POST_CONTENT_LEN = 5000;
 export const MAX_POST_DISABILITY_TAGS = 5;
+
+// TODO: Remove this when auth is properly implemented
+export const USER_ID = '66e26a641737b310a1b2774c';

--- a/src/utils/types/comment.ts
+++ b/src/utils/types/comment.ts
@@ -19,7 +19,7 @@ export const commentLikeSchema = z.object({
 });
 
 export type Comment = ExtendId<z.infer<typeof commentSchema>>;
-export type PopulatedComment = Omit<Comment, 'author' | 'post' | 'replyTo'> & { author: User | null, post: null, replyTo: null };
+export type PopulatedComment = Omit<Comment, 'author' | 'post' | 'replyTo'> & { author: User | null, post: string, replyTo: string | null };
 export type CommentLike = ExtendId<z.infer<typeof commentLikeSchema>>;
 
 export type CommentInput = z.input<typeof commentSchema>;

--- a/src/utils/types/comment.ts
+++ b/src/utils/types/comment.ts
@@ -19,8 +19,14 @@ export const commentLikeSchema = z.object({
 });
 
 export type Comment = ExtendId<z.infer<typeof commentSchema>>;
-export type PopulatedComment = Omit<Comment, 'author' | 'post' | 'replyTo'> & { author: User | null, post: string, replyTo: string | null };
 export type CommentLike = ExtendId<z.infer<typeof commentLikeSchema>>;
+
+export type PopulatedComment = Omit<Comment, 'author' | 'post' | 'replyTo'> & {
+  author: User | null,
+  post: string,
+  replyTo: string | null,
+  liked: boolean
+};
 
 export type CommentInput = z.input<typeof commentSchema>;
 export type CommentLikeInput = z.input<typeof commentLikeSchema>;

--- a/src/utils/types/post.ts
+++ b/src/utils/types/post.ts
@@ -40,9 +40,14 @@ export const postLikeSchema = z.object({
 });
 
 export type Post = ExtendId<z.infer<typeof postSchema>>;
-export type PopulatedPost = Omit<Post, 'author' | 'tags'> & { author: User | null, tags: (Disability | null)[] };
 export type PostSave = ExtendId<z.infer<typeof postSaveSchema>>;
 export type PostLike = ExtendId<z.infer<typeof postLikeSchema>>;
+
+export type PopulatedPost = Omit<Post, 'author' | 'tags'> & {
+  author: User | null,
+  tags: (Disability | null)[],
+  liked: boolean
+};
 
 export type PostInput = z.input<typeof postSchema>;
 export type PostSaveInput = z.input<typeof postSaveSchema>;

--- a/src/utils/types/post.ts
+++ b/src/utils/types/post.ts
@@ -46,7 +46,8 @@ export type PostLike = ExtendId<z.infer<typeof postLikeSchema>>;
 export type PopulatedPost = Omit<Post, 'author' | 'tags'> & {
   author: User | null,
   tags: (Disability | null)[],
-  liked: boolean
+  liked: boolean,
+  saved: boolean
 };
 
 export type PostInput = z.input<typeof postSchema>;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -15,7 +15,10 @@ const config: Config = {
   		},
   		colors: {
   			'blue': '#475CC6',
-  			'med-gray': '#00000099'
+  			'med-gray': '#00000099',
+			'focus-gray': '#636363',
+			'focus-med-gray': '#D9D9D9',
+			'focus-light-gray': '#F3F3F3'
   		},
   		borderRadius: {
   			lg: 'var(--radius)',

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -16,8 +16,8 @@ const config: Config = {
       colors: {
         'theme-blue': '#475CC6',
         'theme-gray': '#636363',
-        'theme-lightgray': '#C7C7C7',
-        'med-gray': '#00000099',
+        'theme-med-gray': '#00000099',
+        'theme-lightgray': '#F3F3F3',
         'dropdown-gray': '#f2f2f2'
       },
       borderRadius: {


### PR DESCRIPTION
### Description

Extends post page functionality to support replying to top-level comments, liking posts and comments, and saving and deleting posts. The server actions to get and populate posts/comments have been heavily refactored using MongoDB aggregations to accommodate these features optimally. Editing posts/comments and deleting comments not currently implemented

Closes #19 

<!-- What does this PR change and why? -->

### Type of change

<!-- Choose one -->
🆕 Feature

### How to Test

<!-- Usually this is just running the yarn command and checking the component on the storybook UI -->

### Checklist

- [ ]  Code follows design and style guidelines
- [ ]  Code is commented with doc blocks
- [ ]  Latest code has been rebased from base branch (usually `develop`)
- [ ]  Commits follow guidelines (concise, squashed, etc)
- [ ]  Github issues have been linked in relevant commits
- [ ]  Relevant reviewers (EM) have been assigned to this PR
