### PR TITLE
charlie/unresolved-reports-indicator

### DIFF
--- a/src/app/(community)/admin-dashboard/reported-content/page.tsx
+++ b/src/app/(community)/admin-dashboard/reported-content/page.tsx
@@ -119,7 +119,7 @@ export default function ReportedContent() {
               );
             })}
             {loading ? (
-              <div className="mt-8 flex items-center justify-center text-theme-blue">
+              <div className="mt-8 flex items-center justify-center text-theme-blue ">
                 <LoaderCircle className="animate-spin" size={32} />
               </div>
             ) : (

--- a/src/app/(community)/admin-dashboard/reported-content/page.tsx
+++ b/src/app/(community)/admin-dashboard/reported-content/page.tsx
@@ -18,6 +18,9 @@ export default function ReportedContent() {
   const { user } = useUser();
   const [loading, setLoading] = useState(true);
 
+  const hasUnresolvedPosts = posts.length !== 0;
+  const hasUnresolvedComments = comments.length != 0;
+
   useEffect(() => {
     fetchUnresolvedReports();
   }, []);
@@ -86,11 +89,26 @@ export default function ReportedContent() {
       <h1 className="mb-7 text-2xl font-bold">Reported Content</h1>
       <Tabs defaultValue="posts" onValueChange={fetchUnresolvedReports}>
         <TabsList className="mb-4">
-          <TabsTrigger size="large" className="text-lg font-semibold" value="posts">
+          <TabsTrigger
+            size="large"
+            className="flex gap-3 text-lg font-semibold"
+            value="posts"
+          >
             Reported Posts
+            {hasUnresolvedPosts && (
+              <span className="aspect-square h-2 w-2 rounded-full bg-red-500"></span>
+            )}
           </TabsTrigger>
-          <TabsTrigger size="large" className="text-lg font-semibold" value="comments">
+
+          <TabsTrigger
+            size="large"
+            className="flex gap-3 text-lg font-semibold"
+            value="comments"
+          >
             Reported Comments
+            {hasUnresolvedComments && (
+              <span className="aspect-square h-2 w-2 rounded-full bg-red-500"></span>
+            )}
           </TabsTrigger>
         </TabsList>
         <TabsContent value="posts">
@@ -102,13 +120,10 @@ export default function ReportedContent() {
             })}
             {loading ? (
               <div className="mt-8 flex items-center justify-center text-theme-blue">
-                <LoaderCircle
-                  className="animate-spin"
-                  size={32}
-                />
+                <LoaderCircle className="animate-spin" size={32} />
               </div>
             ) : (
-              posts.length != 0 || (
+              hasUnresolvedPosts || (
                 <p className="text-center font-bold text-theme-med-gray">
                   No reported posts!
                 </p>
@@ -127,13 +142,10 @@ export default function ReportedContent() {
             })}
             {loading ? (
               <div className="mt-8 flex items-center justify-center text-theme-blue">
-                <LoaderCircle
-                  className="animate-spin"
-                  size={32}
-                />
+                <LoaderCircle className="animate-spin" size={32} />
               </div>
             ) : (
-              comments.length != 0 || (
+              hasUnresolvedComments || (
                 <p className="text-center font-bold text-theme-med-gray">
                   No reported comments!
                 </p>

--- a/src/server/db/actions/ReportActions.ts
+++ b/src/server/db/actions/ReportActions.ts
@@ -37,7 +37,11 @@ export async function getReports(): Promise<Report[]> {
 export async function hasUnresolvedReports(): Promise<boolean> {
   try {
     await dbConnect();
-    const count = await ReportModel.countDocuments({ isResolved: "false" });
+    const count = await ReportModel.countDocuments({
+      isResolved: "false",
+      contentType: { $in: ["Post", "Comment"] },
+    });
+    console.log("APPLE", count);
     return count > 0;
   } catch (error) {
     console.error("Failed to retrieve reports:", error);


### PR DESCRIPTION
### Description

Closes https://github.com/GTBitsOfGood/focus-ga/issues/113

<!-- What does this PR change and why? -->

Adds red dot indicator to reported posts and reported comments tab in reported content tab when there are unresolved reports for either. Adds filter to red dot indicator for the reported content tab to only count any unresolved reports for reported posts or comments, not users.

### Type of change

<!-- Choose one -->
🆕 Feature


### Checklist

- [ ]  Code follows design and style guidelines
- [ ]  Code is commented with doc blocks
- [ ]  Latest code has been rebased from base branch (usually `develop`)
- [ ]  Commits follow guidelines (concise, squashed, etc)
- [ ]  Github issues have been linked in relevant commits
- [ ]  Relevant reviewers (EM) have been assigned to this PR
